### PR TITLE
Remove NetworkChanged Handler

### DIFF
--- a/packages/injected-connector/src/index.ts
+++ b/packages/injected-connector/src/index.ts
@@ -28,7 +28,6 @@ export class InjectedConnector extends AbstractConnector {
   constructor(kwargs: AbstractConnectorArguments) {
     super(kwargs)
 
-    this.handleNetworkChanged = this.handleNetworkChanged.bind(this)
     this.handleChainChanged = this.handleChainChanged.bind(this)
     this.handleAccountsChanged = this.handleAccountsChanged.bind(this)
     this.handleClose = this.handleClose.bind(this)
@@ -59,13 +58,6 @@ export class InjectedConnector extends AbstractConnector {
     this.emitDeactivate()
   }
 
-  private handleNetworkChanged(networkId: string | number): void {
-    if (__DEV__) {
-      console.log("Handling 'networkChanged' event with payload", networkId)
-    }
-    this.emitUpdate({ chainId: networkId, provider: window.ethereum })
-  }
-
   public async activate(): Promise<ConnectorUpdate> {
     if (!window.ethereum) {
       throw new NoEthereumProviderError()
@@ -75,7 +67,6 @@ export class InjectedConnector extends AbstractConnector {
       window.ethereum.on('chainChanged', this.handleChainChanged)
       window.ethereum.on('accountsChanged', this.handleAccountsChanged)
       window.ethereum.on('close', this.handleClose)
-      window.ethereum.on('networkChanged', this.handleNetworkChanged)
     }
 
     if ((window.ethereum as any).isMetaMask) {
@@ -183,7 +174,6 @@ export class InjectedConnector extends AbstractConnector {
       window.ethereum.removeListener('chainChanged', this.handleChainChanged)
       window.ethereum.removeListener('accountsChanged', this.handleAccountsChanged)
       window.ethereum.removeListener('close', this.handleClose)
-      window.ethereum.removeListener('networkChanged', this.handleNetworkChanged)
     }
   }
 


### PR DESCRIPTION
Removed the networkChanged event handler. This event is deprecated by EIP 1193
and causes problems on chains where the networkId is different from the chainId.